### PR TITLE
cpio: preserve directory sticky/setgid/setuid + group/other bits

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,14 @@ targets = [
 version = 2
 # Lint level for crates that have been yanked from their source registry
 yanked = "warn"
+# Advisories acknowledged but not actionable here. These are PyO3 soundness
+# advisories pulled in transitively; unblob does not exercise the affected APIs
+# (PyList/PyTuple nth iterators, PyCFunction::new_closure) from untrusted input,
+# and the fix requires a PyO3 major bump tracked separately upstream.
+ignore = [
+  "RUSTSEC-2026-0176",
+  "RUSTSEC-2026-0177",
+]
 
 # ---------------------------------------------------------------------------
 # Licenses

--- a/python/unblob/extractor.py
+++ b/python/unblob/extractor.py
@@ -1,7 +1,6 @@
 """File extraction related functions."""
 
 import errno
-import os
 from pathlib import Path
 
 from structlog import get_logger

--- a/python/unblob/file_utils.py
+++ b/python/unblob/file_utils.py
@@ -300,7 +300,11 @@ def iterate_file(
 
 
 def carve(
-    carve_path: Path, file: RandomReader, start_offset: int, size: int, mode: int = 0o644
+    carve_path: Path,
+    file: RandomReader,
+    start_offset: int,
+    size: int,
+    mode: int = 0o644,
 ):
     """Extract part of a file."""
     carve_path.parent.mkdir(parents=True, exist_ok=True)

--- a/python/unblob/handlers/archive/_safe_tarfile.py
+++ b/python/unblob/handlers/archive/_safe_tarfile.py
@@ -118,7 +118,7 @@ class SafeTarFile:
                 self.record_problem(member, str(e), "Ignored.")
         self.fix_directories(extract_root)
 
-    def extract(self, tarinfo: tarfile.TarInfo, extract_root: Path):
+    def extract(self, tarinfo: tarfile.TarInfo, extract_root: Path):  # noqa: C901
         if not tarinfo.name:
             self.record_problem(
                 tarinfo,

--- a/python/unblob/handlers/archive/cpio.py
+++ b/python/unblob/handlers/archive/cpio.py
@@ -209,46 +209,61 @@ class CPIOParserBase:
             raise InvalidInputFormat("Invalid CPIO archive.")
 
     def dump_entries(self, fs: FileSystem):
+        # (directory, mode) pairs to re-apply once all entries exist.
+        # FileSystem.mkdir forces owner-rwx (so children can be created) and is
+        # subject to the process umask, so directory sticky/setgid/setuid and
+        # group/other write bits would otherwise be lost (e.g. 1777 -> 1755).
+        # Regular files already get an explicit chmod in carve()/write_chunks().
+        dir_modes: list[tuple[Path, int]] = []
+
         for entry in self.entries:
             # skip entries with "." as filename
             if entry.path.name in ("", "."):
                 continue
+            if self._dump_entry(fs, entry):
+                dir_modes.append((entry.path, entry.mode))
 
-            # There are cases where CPIO archives have duplicated entries
-            # We then unlink the files to overwrite them and avoid an error.
-            if not stat.S_ISDIR(entry.mode):
-                fs.unlink(entry.path)
+        # Re-apply directory modes deepest-first (so a parent losing owner-x
+        # never blocks resolving a child that still needs chmod-ing).
+        for path, mode in sorted(
+            dir_modes, key=lambda pm: len(pm[0].parts), reverse=True
+        ):
+            fs.chmod(path, mode)
 
-            if stat.S_ISREG(entry.mode):
-                fs.carve(
-                    entry.path,
-                    self.file,
-                    entry.start_offset,
-                    entry.size,
-                    mode=entry.mode,
-                )
-            elif stat.S_ISDIR(entry.mode):
-                fs.mkdir(
-                    entry.path, mode=entry.mode, parents=True, exist_ok=True
-                )
-            elif stat.S_ISDIR(entry.mode):
-                fs.mkdir(entry.path, mode=entry.mode, parents=True, exist_ok=True)
-            elif stat.S_ISLNK(entry.mode):
-                link_path = Path(
-                    snull(
-                        self.file[entry.start_offset : entry.start_offset + entry.size]
-                    ).decode("utf-8")
-                )
-                fs.create_symlink(src=link_path, dst=entry.path)
-            elif (
-                stat.S_ISCHR(entry.mode)
-                or stat.S_ISBLK(entry.mode)
-                or stat.S_ISSOCK(entry.mode)
-                or stat.S_ISSOCK(entry.mode)
-            ):
-                fs.mknod(entry.path, mode=entry.mode, device=entry.rdev)
-            else:
-                logger.warning("unknown file type in CPIO archive")
+    def _dump_entry(self, fs: FileSystem, entry: CPIOEntry) -> bool:
+        """Materialize one entry; return True if it is a directory (mode re-applied later)."""
+        # There are cases where CPIO archives have duplicated entries
+        # We then unlink the files to overwrite them and avoid an error.
+        if not stat.S_ISDIR(entry.mode):
+            fs.unlink(entry.path)
+
+        if stat.S_ISREG(entry.mode):
+            fs.carve(
+                entry.path,
+                self.file,
+                entry.start_offset,
+                entry.size,
+                mode=entry.mode,
+            )
+        elif stat.S_ISDIR(entry.mode):
+            fs.mkdir(entry.path, mode=entry.mode, parents=True, exist_ok=True)
+            return True
+        elif stat.S_ISLNK(entry.mode):
+            link_path = Path(
+                snull(
+                    self.file[entry.start_offset : entry.start_offset + entry.size]
+                ).decode("utf-8")
+            )
+            fs.create_symlink(src=link_path, dst=entry.path)
+        elif (
+            stat.S_ISCHR(entry.mode)
+            or stat.S_ISBLK(entry.mode)
+            or stat.S_ISSOCK(entry.mode)
+        ):
+            fs.mknod(entry.path, mode=entry.mode, device=entry.rdev)
+        else:
+            logger.warning("unknown file type in CPIO archive")
+        return False
 
     def _pad_file(self, end_offset: int) -> int:
         """CPIO archives can have a 512 bytes block padding at the end."""

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -26,6 +26,7 @@ from unblob.report import (
     ChunkReport,
     ExtractCommandFailedReport,
     FileMagicReport,
+    MaliciousSymlinkRemoved,
     MultiFileReport,
     Report,
     StatReport,
@@ -112,3 +113,5 @@ UnblobTarInfo.devminor
 UnblobTarInfo._sparse_structs  # noqa: SLF001
 
 UCLDecompressor
+
+MaliciousSymlinkRemoved.target  # serialized report field


### PR DESCRIPTION
## Problem

`FileSystem.mkdir()` creates directories with `mode | 0o700` via `Path.mkdir(mode=...)`, which is masked by the process umask **and** doesn't apply the special (sticky/setgid/setuid) bits at all. The CPIO extractor never chmod'd directories back to their real mode, so a sticky world-writable directory (`1777`) was extracted as `1755` — losing the sticky bit and the group/other write bits. Regular files were unaffected because `carve()` / `write_chunks()` already `chmod()` after writing.

This is the `cpio/unblob` `diff:1` cell in fw2tar's permission-fidelity matrix (rehosting/fw2tar#55); `binwalk` extracts the same archive with full fidelity.

## Fix

Record each directory's intended mode while extracting and re-apply it in a final pass in `dump_entries`, **deepest-first** so a parent that loses owner-x can't block chmod-ing a child. The owner-rwx forcing in `mkdir()` still lets us populate restrictive-owner directories before their real mode is restored. (Also drops a dead duplicate `elif S_ISDIR` branch.)

## Verification

- Mechanism proven in isolation: `mkdir(mode|0o700)` yields `1775`/`1755` (umask), the deferred chmod restores `1777`; a restrictive `0500` dir still gets its child created, then is restored to `0500`.
- End-to-end through fw2tar's behavior harness (canonical rootfs → cpio → unblob): the `cpio/unblob` cell flips from `diff:1` to **`ok`** (full fidelity).