### PR TITLE
Fix AR extraction crash on GNU 64-bit symbol tables (#767)

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -34,5 +34,57 @@ final: prev:
     };
   });
 
+  pythonPackagesExtensions = (prev.pythonPackagesExtensions or [ ]) ++ [
+    (python-final: python-prev: {
+      # The arpy on PyPI/nixpkgs (2.3.0, viraptor) crashes on ar archives that
+      # carry a GNU 64-bit symbol table (a `/SYM64/` member): it misclassifies
+      # the member as a long-name reference and evaluates `int(b"SYM64")`,
+      # raising ValueError. unblob's ar handler only catches ArchiveFormatError,
+      # so the exception aborts chunk calculation and the archive silently fails
+      # to extract (onekey-sec/unblob#767; reproduces on the TP-Link ER7206
+      # firmware). The unblob maintainer's fork (onekey-sec/arpy) carries the
+      # fix; point at it until a fixed arpy is published to PyPI/nixpkgs.
+      #
+      # The fork dropped setup.py for a PEP 621 pyproject (setuptools PEP 517
+      # default backend), so the build must move off the legacy setuptools
+      # phase that the nixpkgs 2.3.0 derivation uses.
+      arpy = python-prev.arpy.overridePythonAttrs (old: {
+        version = "2.3.0-unstable-2026-05-08";
+        src = final.fetchFromGitHub {
+          owner = "onekey-sec";
+          repo = "arpy";
+          rev = "f6746c566b92a193bfe57edb312809b6299ddab1";
+          hash = "sha256-t5LtuXRHLtJaMOCxa/crDVa8sdJjEXTmlIMBdwO3yHM=";
+        };
+        format = "pyproject";
+        nativeBuildInputs =
+          (old.nativeBuildInputs or [ ])
+          ++ (with python-final; [
+            setuptools
+            wheel
+          ]);
+        # The fork's pyproject declares no build backend and leaves the root a
+        # flat layout with a second top-level module (vulture_whitelist.py), so
+        # setuptools auto-discovery refuses to build. Pin the backend and the
+        # single shipped module explicitly.
+        postPatch = (old.postPatch or "") + ''
+          cat >> pyproject.toml <<'EOF'
+
+          [build-system]
+          requires = ["setuptools"]
+          build-backend = "setuptools.build_meta"
+
+          [tool.setuptools]
+          py-modules = ["arpy"]
+          EOF
+        '';
+        # arpy's own test suite (pytest + 90% coverage gate, fixtures under
+        # test/) is not the contract we depend on; unblob's ar integration
+        # fixtures exercise the behaviour we care about.
+        doCheck = false;
+      });
+    })
+  ];
+
   unblob = final.callPackage ./package.nix { };
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,10 @@ features = [
 
 [tool.uv.sources]
 taplo = { git = "https://github.com/tamasfe/taplo", tag = "0.10.0" }
+# PyPI arpy 2.3.0 crashes on GNU 64-bit symbol tables (/SYM64/), see
+# onekey-sec/unblob#767. Use the unblob maintainer's fork, which has the fix,
+# until it is published to PyPI. Keep the rev in sync with overlay.nix.
+arpy = { git = "https://github.com/onekey-sec/arpy", rev = "f6746c566b92a193bfe57edb312809b6299ddab1" }
 
 [build-system]
 build-backend = "maturin"

--- a/tests/integration/archive/ar/__input__/sym64.ar
+++ b/tests/integration/archive/ar/__input__/sym64.ar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa0eb0cfc69e144c0d105071cb667a552b4875897d9d48a86a1f41f9c07666ca
+size 154

--- a/tests/integration/archive/ar/__output__/sym64.ar_extract/foo.o
+++ b/tests/integration/archive/ar/__output__/sym64.ar_extract/foo.o
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf0606727817e0a00024cc500e3a6bea7d65c756c770405cdfb73659ae42ac6f
+size 17

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -23,8 +23,7 @@ wheels = [
 [[package]]
 name = "arpy"
 version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/d5/a1985a4a645a1d66825e4cbb9fa7e8c5d10bf5b41fd32badb38b6b5e55ea/arpy-2.3.0.tar.gz", hash = "sha256:8302829a991cfcef2630b61e00f315db73164021cecbd7fb1fc18525f83f339c", size = 9572, upload-time = "2022-06-11T05:07:00.319Z" }
+source = { git = "https://github.com/onekey-sec/arpy?rev=f6746c566b92a193bfe57edb312809b6299ddab1#f6746c566b92a193bfe57edb312809b6299ddab1" }
 
 [[package]]
 name = "atheris"
@@ -2103,7 +2102,7 @@ type = [
 
 [package.metadata]
 requires-dist = [
-    { name = "arpy", specifier = ">=2.3.0" },
+    { name = "arpy", git = "https://github.com/onekey-sec/arpy?rev=f6746c566b92a193bfe57edb312809b6299ddab1" },
     { name = "attrs", specifier = ">=23.1.0" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "cryptography", specifier = ">=41.0" },


### PR DESCRIPTION
Fixes the AR handler crash tracked upstream as onekey-sec/unblob#767.

## Problem
An ar archive whose symbol index has outgrown 32-bit offsets carries a GNU
**64-bit** symbol table — a member named `/SYM64/`. `arpy` 2.3.0 (the PyPI /
nixpkgs release, viraptor's) classifies any `/`-prefixed name that isn't exactly
`/` as a GNU long-name reference and runs `int(proxy_name[1:])` → `int(b"SYM64")`
→ `ValueError`. unblob's `ar.py:calculate_chunk` only catches
`arpy.ArchiveFormatError`, so the `ValueError` propagates as an *Unhandled
Exception during chunk calculation* and the **entire archive silently fails to
extract** (files lost, only an error log). Reproduces on the TP-Link ER7206
firmware from the upstream issue.

Reproduced minimally against our pinned arpy:
```
REPRODUCED #767 ValueError: invalid literal for int() with base 10: b'SYM64'
```

## Fix
The unblob maintainer's fork **onekey-sec/arpy** already classifies `/SYM64/`
as a symbol table and skips it. Rather than carry our own patch or fork, point
both build paths at that fork until a fixed arpy is published to PyPI/nixpkgs:

- **`overlay.nix`** — override the nixpkgs `arpy` `src` to `onekey-sec/arpy`.
  The fork dropped `setup.py` for a PEP 621 pyproject, so the build moves to
  `pyproject` format; a `postPatch` adds a minimal `[build-system]` +
  `[tool.setuptools] py-modules = ["arpy"]` (the fork's root is a flat layout
  with a second top-level module, which otherwise defeats setuptools
  auto-discovery). arpy's own pytest+coverage suite is skipped — we rely on
  unblob's ar fixtures for behaviour.
- **`pyproject.toml` / `uv.lock`** — pin `arpy` to the same fork rev for the uv
  path so nix and uv agree.

## Test
Adds `tests/integration/archive/ar/__input__/sym64.ar` (a `/SYM64/` member
followed by a real file) + recorded `__output__`. It runs inside the existing
`test_all_handlers[archive.ar]` case (which processes every `__input__` file),
so the previously-crashing input is now a permanent regression guard.

`nix build .#unblob` is green — **1082 passed, 1 skipped, 6 deselected,
5 xfailed**, 0 failed — including the new fixture and all 17 pre-existing ar
fixtures. Manually confirmed the built binary extracts `sym64.ar` (`foo.o`
recovered, symbol table skipped) where the old arpy crashed.

## Follow-up
When a fixed `arpy` lands on PyPI/nixpkgs, drop the `overlay.nix` override and
the `[tool.uv.sources]` pin and bump the version constraint. (A tiny PR to
onekey-sec/arpy adding the missing `[build-system]` would also let us drop the
`postPatch`.)
