### PR TITLE
overlay: make arpy override build under newer nixpkgs too

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -47,7 +47,10 @@ final: prev:
       #
       # The fork dropped setup.py for a PEP 621 pyproject (setuptools PEP 517
       # default backend), so the build must move off the legacy setuptools
-      # phase that the nixpkgs 2.3.0 derivation uses.
+      # phase. Older nixpkgs package arpy with `format = "setuptools"`, newer
+      # ones with `pyproject = true`; force pyproject and clear format so the
+      # override builds under both (a consumer on a newer nixpkgs, e.g. fw2tar,
+      # otherwise trips the `pyproject != null -> format == null` assertion).
       arpy = python-prev.arpy.overridePythonAttrs (old: {
         version = "2.3.0-unstable-2026-05-08";
         src = final.fetchFromGitHub {
@@ -56,7 +59,8 @@ final: prev:
           rev = "f6746c566b92a193bfe57edb312809b6299ddab1";
           hash = "sha256-t5LtuXRHLtJaMOCxa/crDVa8sdJjEXTmlIMBdwO3yHM=";
         };
-        format = "pyproject";
+        pyproject = true;
+        format = null;
         nativeBuildInputs =
           (old.nativeBuildInputs or [ ])
           ++ (with python-final; [


### PR DESCRIPTION
## Problem
The arpy override added in #6 (onekey-sec/arpy, the #767 SYM64 fix) forces
`format = "pyproject"`. That builds fine where nixpkgs still packages arpy with
the legacy `format = "setuptools"` — which is what unblob's *own* pinned nixpkgs
does, so `nix build .#unblob` passed. But a consumer that makes unblob **follow a
newer nixpkgs** (e.g. fw2tar: `inputs.unblob.inputs.nixpkgs.follows = "nixpkgs"`)
gets an arpy that nixpkgs already builds with `pyproject = true`. Setting `format`
on top then trips:

```
error: assertion '(((getFinalPassthru "pyproject") != null) -> (format == null))' failed
```

…which fails the entire downstream build (caught when bumping fw2tar's unblob lock —
its `.#testImage` wouldn't evaluate).

## Fix
Set `pyproject = true; format = null;` in the override. That is accepted whether the
base derivation used the legacy `format` attr (older nixpkgs → we clear it and force
pyproject) or the new `pyproject` attr (newer nixpkgs → no-op), so the override is
nixpkgs-version-agnostic.

## Validation
- `nix build .#unblob` — unblob's own (older) nixpkgs: green.
- fw2tar `.#testImage` with this branch (`--override-input`), i.e. the newer
  nixpkgs that originally tripped the assertion: builds, and the full behaviour
  matrix passes.
