### PR TITLE
cramfs: 7z fallback for opposite-endian images (#5)

### DIFF
--- a/python/unblob/handlers/filesystem/cramfs.py
+++ b/python/unblob/handlers/filesystem/cramfs.py
@@ -1,10 +1,14 @@
 import binascii
 import struct
+import sys
+from pathlib import Path
 
 from unblob.extractors import Command
 
 from ...file_utils import Endian, convert_int32, get_endian
 from ...models import (
+    Extractor,
+    ExtractResult,
     File,
     HandlerDoc,
     HandlerType,
@@ -16,10 +20,39 @@ from ...models import (
 
 CRAMFS_FLAG_FSID_VERSION_2 = 0x00000001
 BIG_ENDIAN_MAGIC = 0x28_CD_3D_45
+BIG_ENDIAN_MAGIC_BYTES = b"\x28\xcd\x3d\x45"
 
 
 def swap_int32(i):
     return struct.unpack("<I", struct.pack(">I", i))[0]
+
+
+class CramFSExtractor(Extractor):
+    """Extract cramfs, choosing the tool by image endianness.
+
+    ``cramfsck`` preserves permissions but only reads host-endian images: on a
+    little-endian host a big-endian cramfs makes it bail ("superblock magic not
+    found") and silently extract nothing. ``7z`` reads either endianness but
+    does not restore unix permissions. So use ``cramfsck`` for native-endian
+    images (full fidelity) and fall back to ``7z`` for the opposite endianness
+    (data is recovered; permissions come out as 7z defaults).
+    """
+
+    def __init__(self):
+        self._native = Command(
+            "cramfsck", "-x", "{outdir}", "{inpath}", make_outdir=False
+        )
+        self._foreign = Command("7z", "x", "-y", "{inpath}", "-o{outdir}")
+
+    def get_dependencies(self) -> list[str]:
+        return self._native.get_dependencies() + self._foreign.get_dependencies()
+
+    def extract(self, inpath: Path, outdir: Path) -> ExtractResult | None:
+        with inpath.open("rb") as f:
+            is_big_endian = f.read(4) == BIG_ENDIAN_MAGIC_BYTES
+        host_big_endian = sys.byteorder == "big"
+        extractor = self._native if is_big_endian == host_big_endian else self._foreign
+        return extractor.extract(inpath, outdir)
 
 
 class CramFSHandler(StructHandler):
@@ -46,7 +79,7 @@ class CramFSHandler(StructHandler):
     """
     HEADER_STRUCT = "cramfs_header_t"
 
-    EXTRACTOR = Command("cramfsck", "-x", "{outdir}", "{inpath}", make_outdir=False)
+    EXTRACTOR = CramFSExtractor()
 
     DOC = HandlerDoc(
         name="CramFS",

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -31,13 +31,10 @@ HANDLERS_PACKAGE_PATH = Path(handlers.__file__).parent
 # divergence from upstream, keyed by the parametrize id (``<type>.<handler>``).
 # Using xfail (not skip/delete) keeps the case running so we are alerted the
 # moment the underlying issue is fixed and the xfail can be removed.
-KNOWN_FORK_XFAILS = {
-    # The fork extracts cramfs with ``cramfsck`` instead of upstream's 7z to
-    # preserve permissions, but cramfsck cannot read big-endian images
-    # ("superblock magic not found"). Tracked as rehosting/fw2tar#5; the guard
-    # is removed when the big-endian fallback lands.
-    "filesystem.cramfs.big_endian": "rehosting/fw2tar#5: cramfsck lacks big-endian cramfs support",
-}
+# Tests that pass upstream but are expected to fail in this fork (strict xfail).
+# Empty: the big-endian cramfs case (rehosting/fw2tar#5) now extracts via the
+# 7z endianness fallback in CramFSExtractor.
+KNOWN_FORK_XFAILS: dict[str, str] = {}
 
 
 def test_handler_docs_have_unique_names():


### PR DESCRIPTION
Fixes rehosting/fw2tar#5 (big-endian cramfs).

## Problem
The fork extracts cramfs with `cramfsck` instead of upstream's `7z` to preserve
permissions. But `cramfsck` only reads **host-endian** images — on our
little-endian build a **big-endian** cramfs makes it bail with *"superblock
magic not found"* and **silently extract nothing**:

```
$ cramfsck -x out fruits.cramfs_be
cramfsck: superblock magic not found      # exit 0, no files
```

The handler already *detects* both endianness (magic `28 CD 3D 45` / `45 3D CD
28`); only the extractor was endian-blind. Seen on the Netgear SRX5308 firmware.

## Fix
`CramFSExtractor` now picks the tool by the image's endianness:

| image vs host | tool | result |
|---|---|---|
| native-endian | `cramfsck` | full fidelity (permissions preserved) |
| opposite-endian | `7z` | tree + contents recovered; perms = 7z defaults |

`7z` reads either byte order, so it recovers big-endian images where `cramfsck`
can't. The only trade-off is that the 7z path doesn't restore unix permissions
(the same trade-off upstream makes for *all* cramfs) — strictly better than
extracting nothing.

> A future improvement could restore the BE permission bits from the cramfs
> inodes (as the extfs/jffs2 handlers now do for their formats); left out here to
> keep the fix focused on the extraction failure.

## Test
Removes the now-obsolete **strict xfail** for `filesystem.cramfs.big_endian`.
That case — plus the `fruits.old` and `fruits.crc_swap` BE variants — now
extracts and matches the recorded `__output__`.

`nix build .#unblob`: **1083 passed, 1 skipped, 6 deselected, 4 xfailed**
(was 1082 / 5 xfailed — the BE cramfs case flipped from xfail to pass). The
little-endian path is unchanged (still `cramfsck`).
