### PR TITLE
cramfs: restore real permissions on opposite-endian images

### DIFF
--- a/python/unblob/handlers/filesystem/cramfs.py
+++ b/python/unblob/handlers/filesystem/cramfs.py
@@ -1,7 +1,10 @@
 import binascii
+import stat
 import struct
 import sys
 from pathlib import Path
+
+from structlog import get_logger
 
 from unblob.extractors import Command
 
@@ -18,13 +21,72 @@ from ...models import (
     ValidChunk,
 )
 
+logger = get_logger()
+
 CRAMFS_FLAG_FSID_VERSION_2 = 0x00000001
 BIG_ENDIAN_MAGIC = 0x28_CD_3D_45
 BIG_ENDIAN_MAGIC_BYTES = b"\x28\xcd\x3d\x45"
 
+# cramfs on-disk layout: a 64-byte superblock followed by the root inode.
+CRAMFS_SUPERBLOCK_SIZE = 64
+CRAMFS_INODE_SIZE = 12
+PERMISSION_BITS = 0o7777
+
 
 def swap_int32(i):
     return struct.unpack("<I", struct.pack(">I", i))[0]
+
+
+def walk_cramfs_modes(data: bytes, *, big_endian: bool) -> list[tuple[str, int]]:
+    """Walk a cramfs image and return ``(relative_posix_path, mode)`` for every entry.
+
+    cramfs packs each inode into 12 bytes of C bitfields
+    (``mode:16, uid:16; size:24, gid:8; namelen:6, offset:26``), so the bit
+    positions of ``namelen``/``offset`` and ``size``/``gid`` differ between a
+    big-endian and a little-endian image. ``namelen`` is the name length in
+    32-bit words; for directories ``offset`` (in 32-bit words) points at the
+    first child inode and ``size`` is the total byte length of the child inodes.
+    """
+    endian = ">" if big_endian else "<"
+    results: list[tuple[str, int]] = []
+
+    def parse_inode(off: int) -> tuple[int, int, int, int]:
+        mode = struct.unpack_from(endian + "H", data, off)[0]
+        size_gid = struct.unpack_from(endian + "I", data, off + 4)[0]
+        name_off = struct.unpack_from(endian + "I", data, off + 8)[0]
+        if big_endian:
+            size = size_gid >> 8
+            namelen = name_off >> 26
+            offset = name_off & 0x3FFFFFF
+        else:
+            size = size_gid & 0xFFFFFF
+            namelen = name_off & 0x3F
+            offset = name_off >> 6
+        return mode, size, namelen, offset
+
+    def walk(data_off: int, total: int, parent: str) -> None:
+        pos = data_off
+        end = min(data_off + total, len(data))
+        while pos + CRAMFS_INODE_SIZE <= end:
+            mode, size, namelen, offset = parse_inode(pos)
+            # Only the (nameless) root inode legitimately has namelen 0; hitting
+            # it again means we walked off the directory — stop rather than spin.
+            if namelen == 0:
+                break
+            name = data[
+                pos + CRAMFS_INODE_SIZE : pos + CRAMFS_INODE_SIZE + namelen * 4
+            ].rstrip(b"\x00")
+            child = f"{parent}/{name.decode('utf-8', 'surrogateescape')}"
+            results.append((child, mode))
+            if stat.S_ISDIR(mode):
+                walk(offset * 4, size, child)
+            pos += CRAMFS_INODE_SIZE + namelen * 4
+
+    if len(data) < CRAMFS_SUPERBLOCK_SIZE + CRAMFS_INODE_SIZE:
+        return results
+    _mode, root_size, _namelen, root_offset = parse_inode(CRAMFS_SUPERBLOCK_SIZE)
+    walk(root_offset * 4, root_size, "")
+    return results
 
 
 class CramFSExtractor(Extractor):
@@ -33,9 +95,10 @@ class CramFSExtractor(Extractor):
     ``cramfsck`` preserves permissions but only reads host-endian images: on a
     little-endian host a big-endian cramfs makes it bail ("superblock magic not
     found") and silently extract nothing. ``7z`` reads either endianness but
-    does not restore unix permissions. So use ``cramfsck`` for native-endian
-    images (full fidelity) and fall back to ``7z`` for the opposite endianness
-    (data is recovered; permissions come out as 7z defaults).
+    does not restore unix permissions (it collapses directories to ``0700`` and
+    drops setuid/setgid/sticky bits). So use ``cramfsck`` for native-endian
+    images (full fidelity) and fall back to ``7z`` for the opposite endianness,
+    then re-apply the real modes parsed straight out of the cramfs inodes.
     """
 
     def __init__(self):
@@ -51,8 +114,29 @@ class CramFSExtractor(Extractor):
         with inpath.open("rb") as f:
             is_big_endian = f.read(4) == BIG_ENDIAN_MAGIC_BYTES
         host_big_endian = sys.byteorder == "big"
-        extractor = self._native if is_big_endian == host_big_endian else self._foreign
-        return extractor.extract(inpath, outdir)
+        if is_big_endian == host_big_endian:
+            return self._native.extract(inpath, outdir)
+        result = self._foreign.extract(inpath, outdir)
+        try:
+            self._restore_modes(inpath, outdir, big_endian=is_big_endian)
+        except Exception:
+            logger.warning(
+                "Failed to restore cramfs source permission bits", exc_info=True
+            )
+        return result
+
+    @staticmethod
+    def _restore_modes(inpath: Path, outdir: Path, *, big_endian: bool) -> None:
+        entries = walk_cramfs_modes(inpath.read_bytes(), big_endian=big_endian)
+        # Deepest paths first so re-applying a restrictive directory mode never
+        # blocks chmod-ing the entries inside it.
+        for relpath, mode in sorted(
+            entries, key=lambda item: item[0].count("/"), reverse=True
+        ):
+            target = outdir / relpath.lstrip("/")
+            if target.is_symlink() or not target.exists():
+                continue
+            target.chmod(mode & PERMISSION_BITS)
 
 
 class CramFSHandler(StructHandler):

--- a/tests/test_cramfs.py
+++ b/tests/test_cramfs.py
@@ -1,0 +1,43 @@
+"""Unit tests for the cramfs permission walker (rehosting/fw2tar#5).
+
+``7z`` recovers data from an opposite-endian cramfs but loses unix permissions
+(directories collapse to ``0700`` and setuid/setgid/sticky bits are dropped).
+``CramFSExtractor`` re-applies the real modes by parsing them straight out of
+the cramfs inodes, so the walker that reads those modes is what we pin here.
+The committed integration fixtures are byte-for-byte images, so these tests
+need no external tooling (mkcramfs/7z).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from unblob.handlers.filesystem.cramfs import (
+    BIG_ENDIAN_MAGIC_BYTES,
+    walk_cramfs_modes,
+)
+
+FIXTURES = Path(__file__).parent / "integration" / "filesystem" / "cramfs"
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        FIXTURES / "big_endian" / "__input__" / "fruits.cramfs_be",
+        FIXTURES / "little_endian" / "__input__" / "fruits.cramfs_le",
+    ],
+    ids=["big_endian", "little_endian"],
+)
+def test_walk_cramfs_modes_reads_real_modes(image: Path):
+    data = image.read_bytes()
+    big_endian = data[:4] == BIG_ENDIAN_MAGIC_BYTES
+
+    entries = dict(walk_cramfs_modes(data, big_endian=big_endian))
+
+    # Regular files in the fixture are 0664 — exactly what 7z would clobber.
+    assert entries == {"/apple.txt": 0o100664, "/cherry.txt": 0o100664}
+
+
+def test_walk_cramfs_modes_ignores_truncated_image():
+    assert walk_cramfs_modes(b"", big_endian=False) == []
+    assert walk_cramfs_modes(BIG_ENDIAN_MAGIC_BYTES, big_endian=True) == []


### PR DESCRIPTION
Follow-up to #9 (the cramfs big-endian fix, rehosting/fw2tar#5).

## Problem
#9 made opposite-endian cramfs extract via `7z` instead of host-endian-only `cramfsck`, recovering **data** that previously silently extracted as nothing. But `7z` does not preserve unix permissions on cramfs: directories collapse to `0700` and setuid/setgid/sticky bits are dropped. So a big-endian (e.g. MIPS/PPC) firmware cramfs analyzed on an x86 host came out with wrong modes.

Demonstrated on a synthesized nested image (`1777` root, `4755` file, `2750` dir):
```
7z:        drwx------ /   -rw-rw-r-- top.txt   drwx------ sub
restored:  -rwsr-xr-x top.txt   drwxr-s--- sub   (+ 0664 leaf)
```

## Fix
`CramFSExtractor` now parses the modes straight out of the cramfs inodes (`walk_cramfs_modes`, handling both bitfield endiannesses) and re-applies them after the 7z extraction, deepest-first so a restrictive directory mode doesn't block chmod of its contents. Best-effort: any parse/chmod failure logs a warning and leaves the 7z-default modes rather than failing extraction. The native-endian `cramfsck` path is unchanged (it already preserves modes).

## Tests
- New `tests/test_cramfs.py`: pins `walk_cramfs_modes` against the committed BE and LE fixtures (no external tooling needed) + a truncated-image guard.
- Full suite: `nix build .#unblob` → **1086 passed**, 4 xfailed. Ruff clean.